### PR TITLE
fix right side calc in section 00 ec math

### DIFF
--- a/00_ec_math/00_ec_math_example_bx.ipynb
+++ b/00_ec_math/00_ec_math_example_bx.ipynb
@@ -355,7 +355,7 @@
     }
    ],
    "source": [
-    "right_side=$(bx ec-multiply $A $b)\n",
+    "right_side=$(bx ec-add $A $b)\n",
     "echo $right_side\n"
    ]
   }


### PR DESCRIPTION
Fixes the last calculation to be `ec-add` so distributive property can be shown